### PR TITLE
Update cookie encryption and format

### DIFF
--- a/certs/create-certs.sh
+++ b/certs/create-certs.sh
@@ -148,4 +148,4 @@ echo '*** Successfully exported root CA to a PKCS#12 file'
 #
 rm example.server.csr
 rm example.client.csr
-rm example.srl
+rm example.ca.srl

--- a/src/main/kotlin/io/curity/bff/BFFConfiguration.kt
+++ b/src/main/kotlin/io/curity/bff/BFFConfiguration.kt
@@ -25,7 +25,6 @@ data class BFFConfigurationProperties(
     var cookieSerializeOptions: CookieSerializeOptions,
     var bffEndpointsPrefix: String,
     var encKey: String,
-    var salt: String,
     var cookieNamePrefix: String,
     var trustedWebOrigins: List<String>
 )
@@ -60,7 +59,6 @@ class BFFConfiguration(configurationProperties: BFFConfigurationProperties)
     val cookieSerializeOptions = configurationProperties.cookieSerializeOptions
     val bffEndpointsPrefix = configurationProperties.bffEndpointsPrefix
     val encKey = configurationProperties.encKey
-    val salt = configurationProperties.salt
     val cookieNamePrefix = configurationProperties.cookieNamePrefix
     val trustedWebOrigins = configurationProperties.trustedWebOrigins
 }

--- a/src/main/kotlin/io/curity/bff/CookieEncrypter.kt
+++ b/src/main/kotlin/io/curity/bff/CookieEncrypter.kt
@@ -50,7 +50,7 @@ class CookieEncrypter(private val config: BFFConfiguration, private val cookieNa
 
         val version = allBytes[0].toInt()
         if (version != CURRENT_VERSION) {
-            throw RuntimeException("The received cookie has invalid version")
+            throw RuntimeException("The received cookie has invalid format")
         }
 
         var offset = VERSION_SIZE

--- a/src/main/kotlin/io/curity/bff/CookieEncrypter.kt
+++ b/src/main/kotlin/io/curity/bff/CookieEncrypter.kt
@@ -1,7 +1,5 @@
 package io.curity.bff
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Service
 import java.security.SecureRandom
 import java.time.Duration
@@ -9,30 +7,16 @@ import java.time.Instant
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import java.util.Arrays;
+import java.util.Base64
 import javax.crypto.Cipher
-import javax.crypto.SecretKey
-import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.SecretKeySpec
 
 @Service
 class CookieEncrypter(private val config: BFFConfiguration, private val cookieName: CookieName)
 {
-
-    private val key = getKeyFromPassword()
-
-    private fun getKeyFromPassword(): SecretKey {
-
-        /*
-        val factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
-        val spec: KeySpec = PBEKeySpec(config.encKey.toCharArray(), config.salt.toByteArray(), 65536, 256)
-        return SecretKeySpec(
-            factory.generateSecret(spec)
-                .encoded, "AES"
-        )*/
-
-        // This is an attempt to enable the BFF token plugin to decrypt the cookie correctly
-        return SecretKeySpec(config.encKey.toByteArray(), 0, config.encKey.length, "AES")
-    }
+    private val encryptionKey = SecretKeySpec(config.encKey.decodeHex(), "AES")
 
     suspend fun getEncryptedCookie(cookieName: String, cookieValue: String, cookieOptions: CookieSerializeOptions) =
         encryptValue(cookieValue).serializeToCookie(cookieName, cookieOptions)
@@ -40,55 +24,47 @@ class CookieEncrypter(private val config: BFFConfiguration, private val cookieNa
     suspend fun getEncryptedCookie(cookieName: String, cookieValue: String): String =
         encryptValue(cookieValue).serializeToCookie(cookieName, config.cookieSerializeOptions)
 
-    suspend fun encryptValue(value: String): String
+    suspend fun encryptValue(plaintext: String): String
     {
-        return withContext(Dispatchers.Default) {
-            kotlin.run {
-                val iv = generateIv()
-                return@withContext "${
-                    iv.iv.toHexString()
-                }:${encrypt("AES/CBC/PKCS5Padding", value, iv)}"
-            }
-        }
-    }
+        val ivBytes = ByteArray(GCM_IV_SIZE)
+        SecureRandom().nextBytes(ivBytes)
+        val parameterSpec = GCMParameterSpec(GCM_TAG_SIZE * 8, ivBytes)
 
-    fun generateIv(): IvParameterSpec
-    {
-        val iv = ByteArray(16)
-        SecureRandom().nextBytes(iv)
-        return IvParameterSpec(iv)
-    }
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, encryptionKey, parameterSpec)
 
-    fun encrypt(
-        algorithm: String, input: String, iv: IvParameterSpec
-    ): String
-    {
-        val cipher: Cipher = Cipher.getInstance(algorithm)
-        cipher.init(Cipher.ENCRYPT_MODE, key, iv)
-        val cipherText: ByteArray = cipher.doFinal(input.toByteArray())
-        return cipherText.toHexString()
-    }
+        val cipherTextBytes = cipher.doFinal(plaintext.toByteArray())
 
-    private fun decrypt(
-        algorithm: String, cipherText: String, key: SecretKey, iv: IvParameterSpec
-    ): String
-    {
-        val cipher = Cipher.getInstance(algorithm)
-        cipher.init(Cipher.DECRYPT_MODE, key, iv)
-        val plainText = cipher.doFinal(cipherText.decodeHex())
-        return String(plainText)
+        val allBytes = byteArrayOf(CURRENT_VERSION.toByte()) + ivBytes + cipherTextBytes
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(allBytes)
     }
 
     suspend fun decryptValueFromCookie(cookieValue: String): String
     {
-        return withContext(Dispatchers.Default) {
-            val valueArray = cookieValue.split(":")
+        val allBytes = Base64.getUrlDecoder().decode(cookieValue);
 
-            val iv = valueArray[0]
-            val cipherText = valueArray[1]
-
-            return@withContext decrypt("AES/CBC/PKCS5Padding", cipherText, key, IvParameterSpec(iv.decodeHex()))
+        val minSize = VERSION_SIZE + GCM_IV_SIZE + 1 + GCM_TAG_SIZE
+        if (allBytes.size < minSize) {
+            throw RuntimeException("The received cookie has an invalid length")
         }
+
+        val version = allBytes[0].toInt()
+        if (version != CURRENT_VERSION) {
+            throw RuntimeException("The received cookie has invalid version")
+        }
+
+        var offset = VERSION_SIZE
+        val ivBytes = Arrays.copyOfRange(allBytes, offset, offset + GCM_IV_SIZE)
+
+        offset = VERSION_SIZE + GCM_IV_SIZE
+        val ciphertextBytes = Arrays.copyOfRange(allBytes, offset, allBytes.size)
+
+        val parameterSpec = GCMParameterSpec(GCM_TAG_SIZE * 8, ivBytes)
+
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.DECRYPT_MODE, encryptionKey, parameterSpec)
+        val decryptedBytes = cipher.doFinal(ciphertextBytes)
+        return String(decryptedBytes)
     }
 
     fun String.decodeHex(): ByteArray
@@ -149,6 +125,11 @@ class CookieEncrypter(private val config: BFFConfiguration, private val cookieNa
 
     companion object
     {
+        const val VERSION_SIZE = 1
+        const val GCM_IV_SIZE = 12
+        const val GCM_TAG_SIZE = 16
+        const val CURRENT_VERSION = 1
+
         private val minusDayInSeconds = -Duration.ofDays(1).toSeconds().toInt()
     }
 }

--- a/src/main/kotlin/io/curity/bff/exception/CookieDecryptionException.kt
+++ b/src/main/kotlin/io/curity/bff/exception/CookieDecryptionException.kt
@@ -1,0 +1,9 @@
+package io.curity.bff.exception
+
+class CookieDecryptionException(cause: Throwable?) : BFFException(
+    "Access denied due to invalid request details",
+    null,
+    401,
+    "unauthorized_request",
+    "A received cookie failed decryption"
+)

--- a/src/main/kotlin/io/curity/bff/exception/InvalidBFFCookieException.kt
+++ b/src/main/kotlin/io/curity/bff/exception/InvalidBFFCookieException.kt
@@ -2,10 +2,10 @@ package io.curity.bff.exception
 
 
 class InvalidBFFCookieException(logMessage: String, cause: Throwable?) : BFFException(
-    "The session is invalid or expired",
-    cause,
+    "Access denied due to invalid request details",
+    null,
     401,
-    "session_expired",
+    "unauthorized_request",
     logMessage
 )
 {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,8 +4,7 @@ bff:
   postLogoutRedirectURI: ${POST_LOGOUT_REDIRECT_URI:https://www.example.local/}
   scope: ${SCOPE:openid profile}
 
-  encKey: ${COOKIE_ENCRYPTION_KEY:NF65meV>Ls#8GP>;!Cnov)rIPRoK^.NP}
-  salt: 'NF62meS>Ls%83P>;!Cdfv)rHTRoK!F)P'
+  encKey: ${COOKIE_ENCRYPTION_KEY:4e4636356d65563e4c73233847503e3b21436e6f7629724950526f4b5e2e4e50}
   cookieNamePrefix: ${COOKIE_NAME_PREFIX:example}
   bffEndpointsPrefix: 'tokenhandler'
   cookieSerializeOptions:

--- a/src/test/groovy/io/curity/bff/UserinfoControllerSpec.groovy
+++ b/src/test/groovy/io/curity/bff/UserinfoControllerSpec.groovy
@@ -36,7 +36,7 @@ class UserinfoControllerSpec extends TokenHandlerSpecification {
         def response = thrown HttpClientErrorException
         response.statusCode == UNAUTHORIZED
         def responseBody = json.parseText(response.responseBodyAsString)
-        responseBody["code"] == "session_expired"
+        responseBody["code"] == "unauthorized_request"
     }
 
     def "Requesting user info with valid cookies should return user data"() {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,8 +4,7 @@ bff:
   postLogoutRedirectURI: https://www.example.com/
   scope: openid profile
 
-  encKey: NF65meV>Ls#8GP>;!Cnov)rIPRoK^.NP
-  salt: 'NF62meS>Ls%83P>;!Cdfv)rHTRoK!F)P'
+  encKey: 4e4636356d65563e4c73233847503e3b21436e6f7629724950526f4b5e2e4e50
   cookieNamePrefix: example
   bffEndpointsPrefix: 'tokenhandler'
   cookieSerializeOptions:

--- a/test/idsvr/deploy.sh
+++ b/test/idsvr/deploy.sh
@@ -57,7 +57,7 @@ fi
 #
 echo "Waiting for the Curity Identity Server ..."
 while [ "$(curl -k -s -o /dev/null -w ''%{http_code}'' -u "$ADMIN_USER:$ADMIN_PASSWORD" "$RESTCONF_BASE_URL?content=config")" != "200" ]; do
-  sleep 2s
+  sleep 2
 done
 
 #

--- a/test/idsvr/docker-compose.yml
+++ b/test/idsvr/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   # A standalone instance of the Curity Identity Server
   #
   curity-idsvr:
-    image: curity.azurecr.io/curity/idsvr:6.6.0
+    image: curity.azurecr.io/curity/idsvr:6.7.0
     hostname: idsvr
     ports:
      - 6749:6749

--- a/test/test-token-handler.sh
+++ b/test/test-token-handler.sh
@@ -239,7 +239,7 @@ fi
 JSON=$(tail -n 1 $RESPONSE_FILE) 
 echo $JSON | jq
 CODE=$(jq -r .code <<< "$JSON")
-if [ "$CODE" != 'session_expired' ]; then
+if [ "$CODE" != 'unauthorized_request' ]; then
    echo "*** User Info returned an unexpected error code"
    exit
 fi


### PR DESCRIPTION
Main changes are:
- Use authenticated symmetric encryption (AES256-GCM), so that tampered cookie bytes return a 401
- Use base64url encoded bytes, to reduce wire size by one third

Note that I've moved the interop library to Bitbucket (under MISC), as recommended by Travis:
https://bitbucket.org/curity/token-handler-encryption-interop